### PR TITLE
Add installation and startup scripts for Streamlit app

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Install system dependencies
+if command -v sudo >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y python3 python3-venv python3-pip ffmpeg espeak
+else
+  apt-get update
+  apt-get install -y python3 python3-venv python3-pip ffmpeg espeak
+fi
+
+# Setup Python virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Installation complete. Activate the environment with 'source .venv/bin/activate'."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+streamlit
+moviepy
+Pillow
+numpy
+pydub
+python-slugify
+requests
+pyttsx3

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Activate virtual environment if exists
+if [ -f ".venv/bin/activate" ]; then
+  source .venv/bin/activate
+fi
+
+# Launch Streamlit app
+streamlit run app/app.py


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing Streamlit and related dependencies
- create `install.sh` to install system packages, set up venv and install Python deps
- add `start.sh` helper to launch the Streamlit application
- fix malformed f-string in `generate_story_ollama` for proper LLM prompts

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d03d05564832099564cc7c9415cc4