### PR TITLE
Fix moviepy import for v2

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -40,7 +40,7 @@ from typing import List, Tuple
 
 import streamlit as st
 from PIL import Image, ImageDraw, ImageFont
-from moviepy.editor import ImageClip, AudioFileClip, concatenate_videoclips
+from moviepy import ImageClip, AudioFileClip, concatenate_videoclips
 from slugify import slugify
 
 # Optional imports


### PR DESCRIPTION
## Summary
- fix import for moviepy v2 API

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d09e084f88320accc36dc3b8dd117