### PR TITLE
Pin moviepy and configure TTS defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,10 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-# Ensure moviepy is installed even if requirements change
-pip install moviepy
+# Pin moviepy to <2.0 so ImageClip still exposes set_duration
+pip install "moviepy<2"
+
+# Provide piper binary if users want the Piper TTS engine
+pip install piper-tts
 
 echo "Installation complete. Activate the environment with 'source .venv/bin/activate'."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
-moviepy
+moviepy<2
 Pillow
 numpy
 pydub

--- a/start.sh
+++ b/start.sh
@@ -6,5 +6,17 @@ if [ -f ".venv/bin/activate" ]; then
   source .venv/bin/activate
 fi
 
+# Ensure locale and TTS voices default to English to avoid espeak errors
+export LANG=${LANG:-en_US.UTF-8}
+export ESPEAK_VOICE=${ESPEAK_VOICE:-en}
+
+# Auto-detect Piper binary and a default voice if available
+if [ -z "$PIPER_PATH" ] && command -v piper >/dev/null 2>&1; then
+  export PIPER_PATH="$(command -v piper)"
+fi
+if [ -z "$PIPER_VOICE" ] && [ -f "voices/en_US-amy-low.onnx" ]; then
+  export PIPER_VOICE="voices/en_US-amy-low.onnx"
+fi
+
 # Launch Streamlit app
 streamlit run app/app.py


### PR DESCRIPTION
## Summary
- Pin moviepy to <2.0 to keep ImageClip.set_duration and avoid rendering errors
- Add piper-tts installation and auto-detect Piper binary/voice at startup
- Default locale and voice to English to prevent eSpeak SetVoiceByName failures

## Testing
- `bash -n install.sh`
- `bash -n start.sh`
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0c463b3c8320aac1eea1d7140040