### PR TITLE
Fix moviepy import for ImageClip

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -40,7 +40,7 @@ from typing import List, Tuple
 
 import streamlit as st
 from PIL import Image, ImageDraw, ImageFont
-from moviepy import ImageClip, AudioFileClip, concatenate_videoclips
+from moviepy.editor import ImageClip, AudioFileClip, concatenate_videoclips
 from slugify import slugify
 
 # Optional imports

--- a/tests/sample_video.py
+++ b/tests/sample_video.py
@@ -1,0 +1,11 @@
+from moviepy.editor import ColorClip
+
+def generate_sample_video(output_path="sample_video.mp4"):
+    """Generate a simple red video clip for testing MoviePy."""
+    clip = ColorClip(size=(320, 240), color=(255, 0, 0), duration=2)
+    clip.write_videofile(output_path, fps=24)
+    return output_path
+
+if __name__ == "__main__":
+    path = generate_sample_video()
+    print(f"Sample video written to {path}")


### PR DESCRIPTION
## Summary
- Fix ImageClip import by pulling classes from moviepy.editor
- Add test script that renders a sample video with MoviePy

## Testing
- `python -m py_compile app/app.py`
- `python tests/sample_video.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0f7db6908320a24482cfe5746212